### PR TITLE
Add Snyk scanning [VEN-414]

### DIFF
--- a/.github/workflows/yubico_security-static_analysis.yml
+++ b/.github/workflows/yubico_security-static_analysis.yml
@@ -1,0 +1,23 @@
+name: Yubico Security - Static Analysis
+
+on:
+    push:
+        branches: [ main ]
+
+jobs:
+    static_analysis:
+        name: "Yubico Security - Static Analysis"
+        uses: Yubico/.github/.github/workflows/yubico_security-static_analysis.yml@main
+        with:
+            snyk-enabled: true
+            # Not all langauges need to be specified. Currently, this only has an affect if you use Go
+            # The rest of the langauges supported by Snyk have tooling installed on the action runner by defualt (or no one at Yubico uses them)
+            # Reference the source workflow and/or 
+            snyk-languages: '["javascript", "java"]' # Not including Swift since that requires the use of cocoapods or Swift Package Manager
+            # This assumes that you have a repository variable with the Snyk org id/slug
+            # Reference: https://docs.github.com/en/actions/learn-github-actions/variables#defining-configuration-variables-for-multiple-workflows
+            snyk-org-id-or-slug: ${{ vars.SNYK_ORG_ID }}
+        secrets:
+            # This assumes that you have a repository secret set with the token
+            # Reference: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
+            snyk-token: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Hi Cody and team!

Here is that long-awaited Snyk scanning workflow. Fortunately, it offloads most of the complexity away towards the behind-the-scenes reusable workflow that it invokes.

All that needs to be done on your end is set a couple variables:
- A repository variable called `SNYK_ORG_ID` with the non-sensitive value of `developer-program`
- A repository secret called `SNYK_TOKEN` with the API token that I will share with you via a secure channel

Here's a preview of what the results look like:
![image](https://github.com/YubicoLabs/passkey-workshop/assets/7481945/4927b08d-70ea-4301-90d1-840506a5fe1e)

The vast majority are license issues that aren't really issues, but we can talk about that more in due time.

I'm happy to help you make adjustments or provide guidance on where to go from here.

Cheers!