### PR TITLE
Add podman / non docker-desktop documentation

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -4,7 +4,7 @@
 
 # make sure we have docker compose v2
 echo "### checking docker compose version"
-docker compose version | grep v2 || { echo docker compose v2 is required; exit; }
+docker compose version | egrep 'version (v)?2' || { echo docker compose v2 is required; exit; }
 
 # use a default environment file unless already present
 if [[ ! -f ".env" ]] ; then

--- a/docs/docs/deploy.md
+++ b/docs/docs/deploy.md
@@ -176,3 +176,26 @@ This will look for any instance of the containers and images set by our deploy s
 
 Once the application has been removed, you will need to run the deploy application script, where you will be given a fresh, "factory-default", version of the application. 
 Any passkeys registered to the old deployment will be unusable.
+
+
+# Troubleshooting
+
+This section covers commmon issues while deploying.
+
+## Docker container disappearing
+
+In case some containers keep disappearing, or you see request timeouts connected to the JDBC, please ensure that you got enough memory allocated to your virtual machine running the docker containers.
+
+### Docker Desktop
+
+If you run docker desktop, please open the settings and change the memory limit.
+
+### Podman
+
+If you use `podman` with `qemu`, please use the following commands to increase the memory size:
+
+```bash
+podman machine stop
+podman machine set --memory 4096
+podman machine start
+```


### PR DESCRIPTION
Using `podman` and `qemu` resulted in a too small memory allowance for mysql and the bank to live in the same machine. 

Fixing this together with @joostd on my local machine and documenting it in a new trouble shooting section of the workshop deploy page.

Also adding exception for `docker-desktop` version including a `v` where there is none for non `docker-desktop` use case.