### PR TITLE
upgrade java-webauthn-server components to 2.5.3

### DIFF
--- a/examples/relyingParties/java-spring/pom.xml
+++ b/examples/relyingParties/java-spring/pom.xml
@@ -80,13 +80,13 @@
         <dependency>
             <groupId>com.yubico</groupId>
             <artifactId>webauthn-server-core</artifactId>
-            <version>2.1.0</version>
+            <version>2.5.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.yubico</groupId>
             <artifactId>webauthn-server-attestation</artifactId>
-            <version>2.1.0</version>
+            <version>2.5.3</version>
         </dependency>
         <dependency>
             <groupId>com.yubico</groupId>


### PR DESCRIPTION
Fixes a problem with unknown keys in FIDO MDS metadata.
See v2.5.3 [release notes](https://github.com/Yubico/java-webauthn-server/releases/tag/2.5.3)
upgrades both webauthn-server-attestation and webauthn-server-core
